### PR TITLE
Expose active song

### DIFF
--- a/js/amplitude.js
+++ b/js/amplitude.js
@@ -1741,7 +1741,8 @@ var Amplitude = (function () {
 		changeVisualization: publicChangeActiveVisualization,
 		addSong: publicAddSong,
 		analyser: analyser,
-		source: source
+		source: source,
+		active: config.active_song
 	};
 
 })();


### PR DESCRIPTION
Exposing the active song allows for manipulations not currently handled by the Amplitude api to occur on that track. 

As an example, here are my specific use cases:
- update currentTime
  - jump ahead 30 seconds
  - jump back 10 seconds
- alter playbackRate (1x, 1.5x, 2x)