### PR TITLE
Added Pause Callback

### DIFF
--- a/js/amplitude.js
+++ b/js/amplitude.js
@@ -281,11 +281,14 @@ var Amplitude = (function () {
 		Pauses the active song. If it's live, it disconnects the stream.
 	*/
 	function privatePause(){
-		config.active_song.pause();
+		privateRunCallback('before_pause');
+
 
 		if( config.active_metadata.live ){
 			privateDisconnectStream();
 		}
+		config.active_song.pause();
+		privateRunCallback('after_pause');
 	}
 
 	/*


### PR DESCRIPTION
Adds a callback for the pause function. Example usage: Pause a song without removing the "amplitude-active-song-container" class - allowing the active element to retain its styling while in pause mode.

Amplitude.config function:

``` javascript
"callbacks":
    "debug": true,
    "after_pause": "active_pause"
    }

});
function active_pause(){
    console.log('PAUSED');
    $('.amplitude-active-song-container').collapse('hide');
    $('.amplitude-active-song-container').prev().removeClass('active-panel');
    $('.amplitude-active-song-container').prev().find('.amplitude-play-pause').removeClass('amplitude-playing').addClass('amplitude-paused');
    $('.amplitude-active-song-container').prev().find('.playlist-play').removeClass('playlist-play').addClass('playlist-paused');
}
```

Functional Method in Amplitude.js

``` javascript
/*
Pauses the active song. If it's live, it disconnects the stream.
*/
function privatePause(){
privateRunCallback('before_pause');


if( config.active_metadata.live ){
    privateDisconnectStream();
}
config.active_song.pause();
privateRunCallback('after_pause');
}
```
