### PR TITLE
Bump bower version to 2.0.0 to match tarball

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "amplitude",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/521dimensions/amplitudejs",
   "authors": [
     "Dan Pastori <dan@521dimensions.com>",


### PR DESCRIPTION
When doing a bower install you get:

```
bower mismatch      Version declared in the json (0.1.0) is different than the resolved one (2.0.0)
```
