### PR TITLE
Update documentation – made up key

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -153,7 +153,7 @@ and reference it anywhere on your page using the 'amplitude-song-info' attribute
 data like:
 
 ```html
-	<span class="made-up-key" amplitude-song-info="made_up_key"></span>
+	<span class="made-up-key" amplitude-song-info="made_up_key" amplitude-main-song-info="true"></span>
 ```
 
 It is important to note that in multiple song environments, the order that you list the songs makes a difference. When utitlizing


### PR DESCRIPTION
Added `amplitude-main-song-info="true"` attribute to the span where we want to be able to display a made up key. Tested on version 3.2.3.