### PR TITLE
Fix key bindings on Firefox

### DIFF
--- a/src/events/handlers.js
+++ b/src/events/handlers.js
@@ -95,7 +95,7 @@ export default {
 		When the keydown event is fired, we determine which function should be run
 		based on what was passed in.
 	--------------------------------------------------------------------------*/
-	keydown: function(){
+	keydown: function( event ){
 		AmplitudeEventHelpers.runKeyEvent( event.which );
 	},
 


### PR DESCRIPTION
Add missing event argument to keydown event handler callback. This makes
key bindings work on Firefox. Without this, pressing a key produces a
"ReferenceError: event is not defined" error. Fixes #248.