### PR TITLE
Update config.js

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -53,7 +53,7 @@ import { version } from "../package.json";
 module.exports = {
   version: version,
 
-  audio: new Audio(),
+  audio: null,
 
   active_metadata: {},
 


### PR DESCRIPTION
don't initialize window.Audio as part of an automatic setup, it will Barf in packagers such as webpack et.all.
instead make it part of the init call - like so:
```
 Amplitude.init({
      audio: new Audio(),
      bindings: {
        37: 'prev',
        39: 'next',
        32: 'play_pause',
      })
```

or alternatively wrap it in a conditional ```if(window && window.Audio)```