### PR TITLE
Subject for discussion: Remove quotes from "song" key

### DIFF
--- a/docs/configuration/callbacks.md
+++ b/docs/configuration/callbacks.md
@@ -58,7 +58,7 @@ callback that has a method to increase the play count:
 
 ```javascript
 Amplitude.init({
-		 "songs": [
+		 songs: [
 				 {
 						 "name": "Song Name 1",
 						 "artist": "Artist Name",
@@ -81,9 +81,9 @@ Amplitude.init({
 						 "cover_art_url": "/cover/art/url.jpg"
 				 }
 		 ],
-		 "callbacks": {
-			 'stop': function(){
-				 console.log('Audio has been stopped.')
+		 callbacks: {
+			 stop: function(){
+				 console.log("Audio has been stopped.")
 			 }
 		 }
  });

--- a/docs/configuration/delay.md
+++ b/docs/configuration/delay.md
@@ -44,7 +44,7 @@ You can set this value on initialization:
 
 ```javascript
 Amplitude.init({
-  songs: ['...'],
+  songs: ["..."],
   delay: 3000
 });
 ```

--- a/docs/configuration/playback-speed.md
+++ b/docs/configuration/playback-speed.md
@@ -41,7 +41,7 @@ By default, AmplitudeJS plays back the audio at the normal speed of `1.0`. Howev
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     playback_speed: 2.0
   });
 ```

--- a/docs/configuration/shuffle.md
+++ b/docs/configuration/shuffle.md
@@ -41,7 +41,7 @@ You can turn shuffle on right away when initializing AmplitudeJS. To do that, si
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     shuffle_on: true
   });
 ```

--- a/docs/configuration/song-objects.md
+++ b/docs/configuration/song-objects.md
@@ -100,7 +100,7 @@ With the introduction of Amplitude FX Song Visualizations, you can apply a speci
 		"url": "/song/url.mp3",
 		"cover_art_url": "/cover/art/url.jpg",
 		"made_up_key": "I'm made up completely",
-    "visualization": "your_visualization_key"
+		"visualization": "your_visualization_key"
 	}
 ```
 Now when the song plays, the visualization you specify will be played in all visualization elements.
@@ -116,9 +116,9 @@ We first start with our individual song object and add a `time_callbacks` object
 		"album": "Album Name",
 		"url": "/song/url.mp3",
 		"cover_art_url": "/cover/art/url.jpg",
-    "time_callbacks": {
-
-    }
+    		"time_callbacks": {
+			
+    		}
 	}
 ```
 
@@ -131,17 +131,17 @@ Within that `time_callbacks` object, we can add functions that get called at a c
 		"album": "Album Name",
 		"url": "/song/url.mp3",
 		"cover_art_url": "/cover/art/url.jpg",
-    "time_callbacks": {
-      1: function(){
-        console.log( "1 second into the song" )
-      },
-      90: function(){
-        console.log( "1 minute 30 seconds into the song" );
-      },
-      110: function(){
-        console.log( "1 minute 50 seconds into the song" );
-      }
-    }
+    		"time_callbacks": {
+      			1: function(){
+        			console.log( "1 second into the song" )
+      			},
+      			90: function(){
+        			console.log( "1 minute 30 seconds into the song" );
+      			},
+      			110: function(){
+        			console.log( "1 minute 50 seconds into the song" );
+      			}
+    		}
 	}
 ```
 

--- a/docs/configuration/start-song-start-playlist.md
+++ b/docs/configuration/start-song-start-playlist.md
@@ -45,7 +45,7 @@ To set a starting song, you simply need to add the `start_song` key and pass it 
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     start_song: 3
   });
 ```
@@ -56,11 +56,11 @@ You can also define which playlist to start with if you have multiple playlists.
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     playlists: {
-      'key_of_starting_playlist': ['...']
+      "key_of_starting_playlist": ["..."]
     }
-    starting_playlist: 'key_of_starting_playlist'
+    starting_playlist: "key_of_starting_playlist"
   });
 ```
 
@@ -70,11 +70,11 @@ Finally, you can set which song you want to start the player with inside which p
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     playlists: {
-      'key_of_starting_playlist': ['...']
+      "key_of_starting_playlist": ["..."]
     }
-    starting_playlist: 'key_of_starting_playlist',
+    starting_playlist: "key_of_starting_playlist",
     starting_playlist_song: 3
   });
 ```

--- a/docs/fx/visualizations.md
+++ b/docs/fx/visualizations.md
@@ -64,7 +64,7 @@ Once you've included the Visualization, you can add it to your visualizations ar
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     visualizations: [
       {
         object: MichaelBromleyVisualization,
@@ -96,7 +96,7 @@ Now that we have our visualizations included, we can define them in a variety of
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     visualizations: [
       {
         object: MichaelBromleyVisualization,
@@ -114,7 +114,7 @@ You can set the `visualization` key to one of the keys for a visualization you r
 You can also set the global visualization through the public method like this:
 
 ```javascript
-  Amplitude.setGlobalVisualization( visualizationKey );
+Amplitude.setGlobalVisualization( visualizationKey );
 ```
 
 Now you just need a visualization element like this:
@@ -131,7 +131,7 @@ You can also define a visualization specific for your playlist. This means that 
 You just need to set up AmplitudeJS with your visualizations and apply the key to the playlist key `visualization`:
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     visualizations: [
       {
         object: MichaelBromleyVisualization,
@@ -141,9 +141,9 @@ You just need to set up AmplitudeJS with your visualizations and apply the key t
       }
     ],
     playlists: {
-      'hip_hop': {
+      "hip_hop": {
         visualization: 'michaelbromley_visualization',
-        songs: ['...']
+        songs: ["..."]
       }
     }
   });
@@ -152,7 +152,7 @@ You just need to set up AmplitudeJS with your visualizations and apply the key t
 Now your visualization is scoped to a playlist! You can also set the visualization through the public facing method like this:
 
 ```javascript
-  Amplitude.setPlaylistVisualization( playlist_key, visualization_key );
+Amplitude.setPlaylistVisualization( playlist_key, visualization_key );
 ```
 
 And to use the visualization scoped for the playlist, you have to add an element with the proper attribute:
@@ -169,8 +169,8 @@ To add a visualization for an individual song, you just need to add the key to t
 ```javascript
   Amplitude.init({
     songs: [{
-      name: 'Test',
-      visualization: 'michaelbromley_visualization'
+      name: "Test",
+      visualization: "michaelbromley_visualization"
     }],
     visualizations: [
       {
@@ -188,7 +188,7 @@ Now whenever the song named 'Test' plays, the visualization defined will show up
 You can also set the visualization for an individual song using the `Amplitude.setSongVisualization(songIndex, visualizationKey)` method like so:
 
 ```javascript
-  Amplitude.setSongVisualization( songIndex, visualizationKey );
+Amplitude.setSongVisualization( songIndex, visualizationKey );
 ```
 
 To display this visualization, simply add an element like this:
@@ -202,12 +202,12 @@ You can even specify a visualization for an individual song within a playlist. T
 
 ```javascript
   Amplitude.init({
-    songs: ['...'],
+    songs: ["..."],
     playlists: {
-      'hip_hop': {
+      "hip_hop": {
         songs: [{
-          name: 'Test',
-          visualization: 'michaelbromley_visualization'
+          name: "Test",
+          visualization: "michaelbromley_visualization"
         }]
       }
     },
@@ -241,7 +241,7 @@ If you are really motivated and want to build your own visualization, you can!! 
 ```javascript
 /*
 	This is a template for how to build a visualization for
-	AmplitudeJS.  The visualization should be modular contain
+	AmplitudeJS. The visualization should be modular contain
 	the methods and variables outlined. You can add any additional
 	methods or variables inside of the object.
 */

--- a/docs/installation/initialization.md
+++ b/docs/installation/initialization.md
@@ -41,7 +41,7 @@ To configure Amplitude.js, you need to call the init function on the Amplitude o
 
 ```javascript
 	Amplitude.init({
-		"songs": [
+		songs: [
 			{
 				"name": "Song Name 1",
 				"artist": "Artist Name",


### PR DESCRIPTION
Subject for discussion:

This example of a playlist is given again in other sections of the documentation, e.g. in "Playlists" (under "Configuration") or "Debug", where the key "song" is used without quotes, it would make sense to make the writing consistent.

This would also mean to apply this change to examples in other places. I would happily add those other places, if this change is accepted and finds the support of the creators of AmplitudeJS.
